### PR TITLE
gnupg: make optional dependencies optional

### DIFF
--- a/pkgs/tools/security/gnupg/21.nix
+++ b/pkgs/tools/security/gnupg/21.nix
@@ -3,9 +3,14 @@
 
 # Each of the dependencies below are optional.
 # Gnupg can be built without them at the cost of reduced functionality.
-, pinentry ? null, x11Support ? true
-, adns ? null, gnutls ? null, libusb ? null, openldap ? null
-, readline ? null, zlib ? null, bzip2 ? null
+, pinentry ? null, x11Support ? false
+, adns ? null, adnsSupport ? true
+, gnutls ? null, gnutlsSupport ? false
+, libusb ? null, usbSupport ? true
+, openldap ? null, openldapSupport ? true
+, readline ? null, readlineSupport ? true
+, zlib ? null, zlibSupport ? true
+, bzip2 ? null, bzip2Support ? true
 }:
 
 with stdenv.lib;
@@ -23,9 +28,14 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    pkgconfig libgcrypt libassuan libksba libiconv npth gettext texinfo
-    readline libusb gnutls adns openldap zlib bzip2
-  ];
+    pkgconfig libgcrypt libassuan libksba libiconv npth gettext texinfo ]
+      ++ optional (adnsSupport) adns
+      ++ optional (bzip2Support) bzip2
+      ++ optional (gnutlsSupport) gnutls
+      ++ optional (usbSupport) libusb
+      ++ optional (openldapSupport) openldap
+      ++ optional (readlineSupport) readline
+      ++ optional (zlibSupport) zlib;
 
   postPatch = stdenv.lib.optionalString stdenv.isLinux ''
     sed -i 's,"libpcsclite\.so[^"]*","${pcsclite}/lib/libpcsclite.so",g' scd/scdaemon.c


### PR DESCRIPTION
###### Motivation for this change

gnupg currently pulls in all optional dependencies (which is significant), even if for instance someone only needs a small tool. This patch makes the dependencies configurable, and makes optional dependencies really optional. 

I've left the defaults as is. Let me know if this is how this should be done, or if there is another best practise to follow.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
